### PR TITLE
Freeparameters

### DIFF
--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -85,7 +85,7 @@ class PyFBU(object):
         for name,err in zip(backgroundkeys,backgroundnormsysts):
             if err<0.:
                 bckgnuisances.append( 
-                    mc.Uniform('norm_%s'%name,value=1.,lower=0.,upper=2.)
+                    mc.Uniform('norm_%s'%name,value=1.,lower=0.,upper=3.)
                     )
             else:
                 bckgnuisances.append( 

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -1,5 +1,5 @@
 import pymc as mc
-from numpy import random, dot, array
+from numpy import random, dot, array, inf
 
 class PyFBU(object):
     """A class to perform a MCMC sampling.
@@ -89,9 +89,10 @@ class PyFBU(object):
                     )
             else:
                 bckgnuisances.append( 
-                    mc.Normal('gaus_%s'%name,value=0.,
-                              mu=0.,tau=1.0,
-                              observed=(False if err>0.0 else True) )
+                    mc.TruncatedNormal('gaus_%s'%name,value=0.,
+                                       mu=0.,tau=1.0,
+                                       a=(-1.0/err if err>0.0 else -inf),b=inf,
+                                       observed=(False if err>0.0 else True) )
                     )
         bckgnuisances = mc.Container(bckgnuisances)
         

--- a/fbu/tests/test_basic.py
+++ b/fbu/tests/test_basic.py
@@ -69,6 +69,23 @@ class Test:
             print expected
             assert_(mean(bin)+std(bin)>expected)
 
+    def test_bckgnorm(self):
+        fbu_ = PyFBU()
+        fbu_.nMCMC = 100000
+        fbu_.nBurn = 20000
+        fbu_.data = [100,150]        
+        fbu_.response = [[0.08,0.02],[0.02,0.08]]
+        fbu_.lower = [0,0]
+        fbu_.upper = [3000,3000]
+        fbu_.background       = {'bckg1': [5,20]}
+        fbu_.backgroundsyst   = {'bckg1': -1.}
+        fbu_.run()
+        trace = fbu_.trace
+        for bin,expected in zip(trace,[700,1000]):
+            print 'mean',mean(bin),'std',std(bin)
+            print expected
+            assert_(mean(bin)+std(bin)>expected)
+
     def test_objsyst(self):
         fbu_ = PyFBU()
         fbu_.nMCMC = 100000

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 DISTNAME = 'fbu'
 DESCRIPTION = "PyFBU"
 #VERSION = '0.0.2'
-VERSION = '0.0.3dev.2'
+VERSION = '0.0.3dev.3'
 AUTHOR = 'Davide Gerbaudo, Clement Helsens and Francesco Rubbo'
 AUTHOR_EMAIL = 'rubbo.francesco@gmail.com'
 URL = 'https://github.com/gerbaudo/fbu'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 DISTNAME = 'fbu'
 DESCRIPTION = "PyFBU"
 #VERSION = '0.0.2'
-VERSION = '0.0.3dev.1'
+VERSION = '0.0.3dev.2'
 AUTHOR = 'Davide Gerbaudo, Clement Helsens and Francesco Rubbo'
 AUTHOR_EMAIL = 'rubbo.francesco@gmail.com'
 URL = 'https://github.com/gerbaudo/fbu'


### PR DESCRIPTION
This introduces two features:
- uninformative priors for background normalizations in the range \[0,3\] (not customizable for now): 

        fbu_.backgroundsyst   = {'bckg1': -1.}

- hard-coded boundary at 0. for background normalizations.

test_bckgnorm tests these features.