### PR TITLE
fix numpy versiom for compatibility with pymc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,16 @@ before_install:
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
-  - chmod +x miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update -q conda
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
+
 # Install packages
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose dateutil pandas statsmodels

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
-  - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose dateutil pandas statsmodels
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy=1.10.1 scipy matplotlib nose dateutil pandas statsmodels
   # Coverage packages are on my binstar channel
   - conda install --yes -c dan_blanchard python-coveralls nose-cov
   - pip install pymc==2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
-  - conda update --yes conda
+  - conda update -q conda
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ notifications:
 # Setup anaconda
 before_install:
   - sudo apt-get install gfortran
-  - wget http://repo.continuum.io/miniconda/Miniconda-3.3.0-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - hash -r
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ classifiers = [
     'Operating System :: OS Independent',
     ]
 
-required = ['numpy>=1.7.0','scipy>=0.12.0','matplotlib>=1.2.1','pymc==2.3','emcee']
+required = ['numpy==1.10.1','scipy>=0.12.0','matplotlib>=1.2.1','pymc==2.3','emcee']
 
 setup(
     name=DISTNAME,


### PR DESCRIPTION
Hi Davide, 

as discussed we need a specific version of numpy to work with pymc 2.3
I haven't tried to remove the ==2.3 for pymc, but this setup seems to work well for me.
We will see it in the travis test I guess!

Clement