### PR TITLE
Expose more PyMC3 sampling options to user

### DIFF
--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -21,6 +21,7 @@ class PyFBU(object):
         self.nCores = 1 # number of CPU threads to utilize
         self.nChains = 2 # number of Markov chains to sample
         self.target_accept = 0.95
+        self.discard_tuned_samples = True # whether to discard tuning steps from posterior
         self.lower = lower  # lower sampling bounds
         self.upper = upper  # upper sampling bounds
         #                                     [unfolding model parameters]
@@ -146,7 +147,8 @@ class PyFBU(object):
                                   observed=array(data))
 
             trace = mc.sample(self.nMCMC,tune=self.nTune,cores=self.nCores,
-                              chains=self.nChains, target_accept=self.target_accept)
+                              chains=self.nChains, target_accept=self.target_accept,
+                              discard_tuned_samples=self.discard_tuned_samples)
 
             self.trace = [trace['truth%d'%bin][:] for bin in range(truthdim)]
             self.nuisancestrace = {}

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -40,6 +40,7 @@ class PyFBU(object):
         self.verbose   = verbose
         self.name      = name
         self.monitoring = monitoring
+        self.sampling_progressbar = True
 
     #__________________________________________________________
     def validateinput(self):
@@ -146,9 +147,18 @@ class PyFBU(object):
             unfolded = mc.Poisson('unfolded', mu=unfold(),
                                   observed=array(data))
 
+            import time
+            from datetime import timedelta
+            init_time = time.time()
             trace = mc.sample(self.nMCMC,tune=self.nTune,cores=self.nCores,
                               chains=self.nChains, target_accept=self.target_accept,
-                              discard_tuned_samples=self.discard_tuned_samples)
+                              discard_tuned_samples=self.discard_tuned_samples,
+                              progressbar=self.sampling_progressbar)
+            finish_time = time.time()
+            print('Elapsed {0} ({1:.2f} samples/second)'.format(
+                str(timedelta(seconds=(finish_time-init_time))).split('.')[0],
+                (self.nMCMC+self.nTune)*self.nChains/(finish_time-init_time)
+            ))
 
             self.trace = [trace['truth%d'%bin][:] for bin in range(truthdim)]
             self.nuisancestrace = {}

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -20,7 +20,7 @@ class PyFBU(object):
         self.nMCMC = 10000 # N of sampling points
         self.nCores = 1 # number of CPU threads to utilize
         self.nChains = 2 # number of Markov chains to sample
-        self.target_accept = 0.95
+        self.nuts_kwargs = None
         self.discard_tuned_samples = True # whether to discard tuning steps from posterior
         self.lower = lower  # lower sampling bounds
         self.upper = upper  # upper sampling bounds
@@ -151,7 +151,7 @@ class PyFBU(object):
             from datetime import timedelta
             init_time = time.time()
             trace = mc.sample(self.nMCMC,tune=self.nTune,cores=self.nCores,
-                              chains=self.nChains, target_accept=self.target_accept,
+                              chains=self.nChains, nuts_kwargs=self.nuts_kwargs,
                               discard_tuned_samples=self.discard_tuned_samples,
                               progressbar=self.sampling_progressbar)
             finish_time = time.time()

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -4,9 +4,9 @@ import theano
 
 class PyFBU(object):
     """A class to perform a MCMC sampling.
-    
+
     [more detailed description should be added here]
-    
+
     All configurable parameters are set to some default value, which
     can be changed later on, but before calling the `run` method.
     """
@@ -18,6 +18,8 @@ class PyFBU(object):
         #                                     [MCMC parameters]
         self.nTune = 1000
         self.nMCMC = 10000 # N of sampling points
+        self.nCores = 1 # number of CPU threads to utilize
+        self.nChains = 2 # number of Markov chains to sample
         self.target_accept = 0.95
         self.lower = lower  # lower sampling bounds
         self.upper = upper  # upper sampling bounds
@@ -37,7 +39,7 @@ class PyFBU(object):
         self.verbose   = verbose
         self.name      = name
         self.monitoring = monitoring
-        
+
     #__________________________________________________________
     def validateinput(self):
         def checklen(list1,list2):
@@ -74,8 +76,8 @@ class PyFBU(object):
             signalobjsysts = array([self.objsyst['signal'][key] for key in objsystkeys])
             if nbckg>0:
                 backgroundobjsysts = array([])
-                backgroundobjsysts = array([[self.objsyst['background'][syst][bckg] 
-                                             for syst in objsystkeys] 
+                backgroundobjsysts = array([[self.objsyst['background'][syst][bckg]
+                                             for syst in objsystkeys]
                                             for bckg in backgroundkeys])
 
         recodim  = len(data)
@@ -88,12 +90,12 @@ class PyFBU(object):
             truth = wrapper(priorname=self.prior,
                             low=self.lower,up=self.upper,
                             other_args=self.priorparams)
-            
+
             if nbckg>0:
                 bckgnuisances = []
                 for name,err in zip(backgroundkeys,backgroundnormsysts):
                     if err<0.:
-                        bckgnuisances.append( 
+                        bckgnuisances.append(
                             mc.Uniform('norm_%s'%name,lower=0.,upper=3.)
                             )
                     else:
@@ -103,10 +105,10 @@ class PyFBU(object):
                                           mu=0.,tau=1.0)
                             )
                 bckgnuisances = mc.math.stack(bckgnuisances)
-        
+
             if nobjsyst>0:
                 objnuisances = [ mc.Normal('gaus_%s'%name,mu=0.,tau=1.0#,
-                                           #observed=(True if self.systfixsigma!=0 else False) 
+                                           #observed=(True if self.systfixsigma!=0 else False)
                                            )
                                  for name in objsystkeys]
                 objnuisances = mc.math.stack(objnuisances)
@@ -114,20 +116,20 @@ class PyFBU(object):
         # define potential to constrain truth spectrum
             if self.regularization:
                 truthpot = self.regularization.getpotential(truth)
-        
+
         #This is where the FBU method is actually implemented
             def unfold():
                 smearbckg = 1.
                 if nbckg>0:
-                    bckgnormerr = [(-1.+nuis)/nuis if berr<0. else berr 
+                    bckgnormerr = [(-1.+nuis)/nuis if berr<0. else berr
                                          for berr,nuis in zip(backgroundnormsysts,bckgnuisances)]
                     bckgnormerr = mc.math.stack(bckgnormerr)
-                    
+
                     smearedbackgrounds = backgrounds
                     if nobjsyst>0:
-                        smearbckg = smearbckg + theano.dot(objnuisances,backgroundobjsysts) 
+                        smearbckg = smearbckg + theano.dot(objnuisances,backgroundobjsysts)
                         smearedbackgrounds = backgrounds*smearbckg
-                        
+
                     bckg = theano.dot(1. + bckgnuisances*bckgnormerr,smearedbackgrounds)
 
                 tresmat = array(resmat)
@@ -140,11 +142,12 @@ class PyFBU(object):
                     out = bckg + out
                 return out
 
-            unfolded = mc.Poisson('unfolded', mu=unfold(), 
+            unfolded = mc.Poisson('unfolded', mu=unfold(),
                                   observed=array(data))
 
-            trace = mc.sample(self.nMCMC,tune=self.nTune,target_accept=self.target_accept)
-        
+            trace = mc.sample(self.nMCMC,tune=self.nTune,cores=self.nCores,
+                              chains=self.nChains, target_accept=self.target_accept)
+
             self.trace = [trace['truth%d'%bin][:] for bin in range(truthdim)]
             self.nuisancestrace = {}
             if nbckg>0:


### PR DESCRIPTION
Currently, PyFBU is not exposing a number of useful options to user that can be configured in PyMC3: 

1. Number of chains and CPU threads to use: By default, PyMC3 decides automatically based on available resources how many chains and threads are used, and this effectively changes the number of samples performed, because the sampling steps parameter is per chain.
2. Keep or discard tuning samples: Default is to discard, but for some convergences investigations it might be useful to keep tuning samples and examine monitoring plots with these samples included.
3. Option to toggle on/off the sampling progress bar.
4. Expose the `nuts_kwargs` options dictionary. PyMC3 commonly uses NUTS sampler for a lot of continuous probability density functions. There are a number of [useful options](https://docs.pymc.io/api/inference.html#module-pymc3.sampling), such as `target_accept`.

For 1. I have added configuration parameters `nCores` and `nChains` for this. By default, `nCores=1` and `nChains=2` (per default in PyMC3,  >1 chain recommended for some convergence tests).

For 3. In addition to exposing the option to user, I have added a print statement for the total elapsed sampling time and average samples/second. A crude method of measurement is used, but it does give roughly the correct estimate.

For 4. I would simply propose to expose the `nuts_kwargs` to user. By default it is `None`, to make sure we don't break anything if NUTS sampler is not used. It would be up for users to set non-default options with this dictionary if they want to use NUTS. In addition the previously exposed parameter `target_accept` would be removed -- the way it is passed to `sample` method does nothing, as PyMC3 API changed and `target_accept` is specific to some samplers such as NUTS.

P.S. It seems my vim setup removed some unnecessary trailing white spaces in the code. If these sort-of redundant, cluttering changes are undesirable in the merge requests, let me know. 